### PR TITLE
Add GitHub Actions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Continuous Integration
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build and test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci
+    - run: cp ./config.sample.js ./config.js
+    - run: npm test
+
+  coverage:
+    name: Coverage
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci
+    - run: cp ./config.sample.js ./config.js
+    - run: npm run coverage
+    - uses: actions/upload-artifact@v2
+      with:
+        name: Coverage ${{ matrix.node-version }}
+        path: |
+          coverage/

--- a/buidler.config.js
+++ b/buidler.config.js
@@ -1,8 +1,7 @@
 const config = require('./config')
 
 usePlugin('@nomiclabs/buidler-waffle')
-usePlugin("@nomiclabs/buidler-etherscan");
-usePlugin('buidler-gas-reporter')
+usePlugin('@nomiclabs/buidler-etherscan')
 usePlugin('solidity-coverage')
 
 // This is a sample Buidler task. To learn how to create your own go to
@@ -26,7 +25,7 @@ module.exports = {
         },
     },
 
-    defaultNetwork: "buidlerevm",
+    defaultNetwork: 'buidlerevm',
 
     networks: config.networks,
     etherscan: config.etherscan,


### PR DESCRIPTION
- Creates GitHub Actions.
- Removes `buidler-gas-reporter` because it needs a running `ganache-cli` in background. Also `buidler-gas-reporter` does not add a lot of value.
- Uploads coverage files as artifacts.

At the moment the coverage files are not directly visible in GitHub, they need to be downloaded first. There is an issue asking for direct browsing of html artifacts (similar to circle-ci) https://github.com/actions/upload-artifact/issues/14 for more info.

Fixes #2 
